### PR TITLE
Added NoException

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ For strictly stream enhancements, go to the [Streams libraries](#streams-librari
 * [Derive4J](https://github.com/derive4j/derive4j) - Code generator for user-defined algebraic data types (aka sum types) based on an enhanced "visitor" pattern. Provides structural pattern matching, laziness, functional setters (return a copy of an object with one field modified) & more. :8ball:
 * [Vavr](http://www.vavr.io/) - Adds the notion of Tuples, along with immutable Values and Pattern Matching, to make it easier to write more functional Java code. (Formerly known as Javaslang.) :8ball:
 * [jOOλ](https://github.com/jOOQ/jOOL) - Part of the jOOQ series of libraries, provides more Functions, Tuples, and `Seq` that provides methods like `crossJoin()`, `join()`, and `groupBy()`. :8ball:
+* [NoException](https://noexception.machinezoo.com/) - Allows checked exceptions in functional interfaces and converts exceptions to Optional return. :8ball:
 * [ProtonPack](https://github.com/poetix/protonpack) - Offers about a dozen utilities for `Stream`, e.g., `takeWhile`, `zip`, `aggregate`, and a `unique` collector. :8ball:
 
 ## General-purpose libraries


### PR DESCRIPTION
I am proposing NoException, which takes functional approach to exception handling, removing friction between Java 8's lambdas and exceptions.

NoException is a superset of functionality found in other similar libraries (listed on NoException site). Arguably, NoException also has a cleaner API. jOOL, listed here already, contains something similar, but that functionality is not mentioned in its description and it's less advanced than NoException.

Disclaimer: I am the author of NoException.